### PR TITLE
ice: add ice driver netmap support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ netmap-tmpdir
 netmap_linux_config.h
 netmap-tmp.c
 i40e*/
+ice*/
 veth.c
 failed-patches
 apps/lb/lb

--- a/LINUX/README.md
+++ b/LINUX/README.md
@@ -4,7 +4,7 @@ This file contains instructions on how to build, install and use Netmap
 on Linux.
 This directory contains Linux-specific code to let netmap work on
 Linux.
-Native support is available for r8169, ixgbe, igb, i40e, e1000, e1000e,
+Native support is available for r8169, ixgbe, igb, i40e, ice, e1000, e1000e,
 virtio-net, and forcedeth Linux drivers.
 
 Netmap relies on a kernel module (`netmap.ko`) and modified
@@ -22,7 +22,7 @@ the patches/ directory.  Common driver modifications are in the .h
 files in this directory. Note that the patches for e1000, forcedeth,
 virtio-net have been prepared on the vanilla kernel: this is usually
 sufficient for Debian/Ubuntu, but it often fails on Red Hat/CentOS.
-The patches for igb, e1000e, ixgbe and i40e, instead, are against
+The patches for igb, e1000e, ixgbe, ice and i40e, instead, are against
 a specific version of the out-of-tree Intel drivers, and should compile
 without any problem on the same systems where the original drivers do.
 
@@ -91,7 +91,7 @@ drivers usually works. In method 2 the patches will be guaranteed to
 apply, but compilation may fail since the out-of-tree drivers may
 not support your kernel.
 
-By default `e1000e`, `i40e`, `ixgbe`, `ixgbevf` and igb use method 2,
+By default `e1000e`, `i40e`, `ice`, `ixgbe`, `ixgbevf` and `igb` use method 2,
 while `e1000`, `r8169.c`, `forcedeth.c`, `veth.c` and `virtio_net.c`
 drivers use method 1\.
 The list of supported drivers can be obtained by running configure

--- a/LINUX/configure
+++ b/LINUX/configure
@@ -113,7 +113,7 @@ subsys enable ptnetmap
 
 # available drivers
 driver_avail="stmmac r8169.c virtio_net.c forcedeth.c veth.c \
-	e1000 e1000e igb ixgbe ixgbevf i40e vmxnet3 mlx5"
+	e1000 e1000e igb ixgbe ixgbevf i40e ice vmxnet3 mlx5"
 # enabled drivers (bitfield)
 driver=
 drv()
@@ -135,6 +135,7 @@ edrv enable igb
 edrv enable ixgbe
 edrv enable ixgbevf
 edrv enable i40e
+edrv enable ice
 edrv enable mlx5
 edrv enable virtio_net.c
 
@@ -2266,6 +2267,28 @@ EOF
 	}
 EOF
   fi # i40e
+
+  if drv enabled ice; then
+    add_test 'define ICE_PTR_ARRAY' <<EOF
+        #include "ice/ice.h"
+
+        struct ice_ring *
+        dummy(struct ice_vsi *vsi) {
+             return vsi->tx_rings[0];
+        }
+EOF
+
+   add_test 'define ice_PTR_STATE' <<EOF
+        #include "ice/ice.h"
+        #include <linux/bitops.h>
+        #pragma GCC diagnostic error "-Wincompatible-pointer-types"
+
+        int
+        dummy(struct ice_pf *pf) {
+               return test_and_set_bit(1, &pf->state);
+        }
+EOF
+  fi # ice
 
   if drv enabled igb; then
     add_test 'have IGB_RD32' <<EOF

--- a/LINUX/default-config.mak.in_
+++ b/LINUX/default-config.mak.in_
@@ -83,6 +83,7 @@ e1000e@prepare := $(if $(filter $(e1000e@v),3.8.4),@SRCDIR@/intel-fix.sh e1000e,
 ixgbevf@prepare := $(if $(filter $(ixgbevf@v),4.7.1 4.8.1 4.9.3 4.10.2 4.11.1),@SRCDIR@/intel-fix.sh ixgbevf,)
 ixgbe@prepare := $(if $(filter $(ixgbe@v),5.8.1 5.9.4 5.10.2 5.11.3),@SRCDIR@/intel-fix.sh ixgbe,)
 i40e@prepare := $(if $(filter $(i40e@v),2.12.6 2.14.13 2.15.9),@SRCDIR@/intel-fix.sh i40e,)
+ice@prepare := $(if $(filter $(ice@v),1.6.7),@SRCDIR@/intel-fix.sh ice,)
 
 # some additional, driver-specific configuration
 stmmac@conf := CONFIG_STMMAC_ETH
@@ -93,9 +94,10 @@ $(eval $(call default,ixgbevf,4.3.2))
 $(eval $(call default,e1000e,3.4.0.2))
 $(eval $(call default,igb,5.3.5.20))
 $(eval $(call default,i40e,2.4.6))
+$(eval $(call default,ice,1.6.7))
 
 # only define the drivers that are selected after the --(no-)ext-drivers= processing (variable E_DRIVERS)
-$(foreach d,$(filter ixgbe ixgbevf e1000e igb i40e,$(E_DRIVERS)),$(eval $(call intel_driver,$d,$($(d)@v))))
+$(foreach d,$(filter ixgbe ixgbevf e1000e igb i40e ice,$(E_DRIVERS)),$(eval $(call intel_driver,$d,$($(d)@v))))
 
 
 define mellanox_driver

--- a/LINUX/dkms/dkms.conf
+++ b/LINUX/dkms/dkms.conf
@@ -46,6 +46,11 @@ BUILT_MODULE_NAME[8]=i40e
 BUILT_MODULE_LOCATION[8]=i40e/
 DEST_MODULE_LOCATION[8]=/kernel/drivers/net/ethernet/intel/i40e/
 
+# ice driver
+BUILT_MODULE_NAME[8]=ice
+BUILT_MODULE_LOCATION[8]=ice/
+DEST_MODULE_LOCATION[8]=/kernel/drivers/net/ethernet/intel/ice/
+
 # vmxnet3 driver
 BUILT_MODULE_NAME[9]=vmxnet3
 BUILT_MODULE_LOCATION[9]=vmxnet3/

--- a/LINUX/final-patches/intel--ice--1.6.7
+++ b/LINUX/final-patches/intel--ice--1.6.7
@@ -1,0 +1,202 @@
+diff --git a/ice/Makefile b/ice/Makefile
+index 5f004daea0c9..f1eea8ba0f0e 100644
+--- a/ice/Makefile
++++ b/ice/Makefile
+@@ -32,9 +32,9 @@ endif # KERNEL_CONFIG_INCLUDED
+ ccflags-y += -I$(src)
+ subdir-ccflags-y += -I$(src)
+ 
+-obj-$(CONFIG_ICE) += ice.o
++obj-$(CONFIG_ICE) += ice$(NETMAP_DRIVER_SUFFIX).o
+ 
+-ice-y := ice_main.o	\
++ice$(NETMAP_DRIVER_SUFFIX)-y := ice_main.o	\
+ 	 ice_controlq.o	\
+ 	 ice_common.o	\
+ 	 ice_nvm.o	\
+@@ -60,32 +60,32 @@ ice-y := ice_main.o	\
+ 	 ice_lag.o		\
+ 	 ice_fwlog.o		\
+ 	 ice_ethtool.o
+-ice-$(CONFIG_NET_DEVLINK:m=y) += ice_devlink.o ice_fw_update.o
+-ice-$(CONFIG_NET_DEVLINK:m=y) += ice_eswitch.o ice_repr.o
+-ice-$(CONFIG_MFD_CORE:m=y) += ice_idc.o
+-ice-$(CONFIG_DEBUG_FS) += ice_debugfs.o
+-ice-$(CONFIG_PCI_IOV) += ice_virtchnl_allowlist.o
+-ice-$(CONFIG_PCI_IOV) += ice_dcf.o
+-ice-$(CONFIG_PCI_IOV) += ice_virtchnl_fdir.o
+-ice-$(CONFIG_PCI_IOV) += ice_virtchnl_pf.o ice_sriov.o ice_vf_vsi_vlan_ops.o
+-ice-$(CONFIG_PTP_1588_CLOCK:m=y) += ice_ptp.o ice_ptp_hw.o
+-ice-$(CONFIG_PTP_1588_CLOCK:m=y) += ice_cgu_ops.o ice_cgu_util.o
+-ice-$(CONFIG_DCB) += ice_dcb.o ice_dcb_nl.o ice_dcb_lib.o
+-ice-$(CONFIG_RFS_ACCEL) += ice_arfs.o
+-ice-$(CONFIG_XDP_SOCKETS) += ice_xsk.o
+-ice-y += kcompat.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_NET_DEVLINK:m=y) += ice_devlink.o ice_fw_update.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_NET_DEVLINK:m=y) += ice_eswitch.o ice_repr.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MFD_CORE:m=y) += ice_idc.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_DEBUG_FS) += ice_debugfs.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_PCI_IOV) += ice_virtchnl_allowlist.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_PCI_IOV) += ice_dcf.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_PCI_IOV) += ice_virtchnl_fdir.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_PCI_IOV) += ice_virtchnl_pf.o ice_sriov.o ice_vf_vsi_vlan_ops.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_PTP_1588_CLOCK:m=y) += ice_ptp.o ice_ptp_hw.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_PTP_1588_CLOCK:m=y) += ice_cgu_ops.o ice_cgu_util.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_DCB) += ice_dcb.o ice_dcb_nl.o ice_dcb_lib.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_RFS_ACCEL) += ice_arfs.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_XDP_SOCKETS) += ice_xsk.o
++ice$(NETMAP_DRIVER_SUFFIX)-y += kcompat.o
+ # Use kcompat pldmfw.c if kernel does not provide CONFIG_PLDMFW
+ ifndef CONFIG_PLDMFW
+-ice-y += kcompat_pldmfw.o
++ice$(NETMAP_DRIVER_SUFFIX)-y += kcompat_pldmfw.o
+ endif
+ # Use kcompat DIMLIB if kernel doesn't provide it
+ ifndef CONFIG_DIMLIB
+-ice-y += kcompat_dim.o kcompat_net_dim.o
++ice$(NETMAP_DRIVER_SUFFIX)-y += kcompat_dim.o kcompat_net_dim.o
+ endif
+ else	# ifneq($(KERNELRELEASE),)
+ # normal makefile
+ 
+-DRIVER := ice
++DRIVER := ice${NETMAP_DRIVER_SUFFIX}
+ 
+ COMMON_MK ?= $(wildcard common.mk)
+ ifeq (${COMMON_MK},)
+@@ -111,7 +111,7 @@ endif
+
+ all:
+        +$(call kernelbuild,modules)
+-       @gzip -c ../${DRIVER}.${MANSECTION} > ${DRIVER}.${MANSECTION}.gz
++       @gzip -c ../ice.${MANSECTION} > ${DRIVER}.${MANSECTION}.gz
+ ifneq ($(wildcard lttng),)
+        $(MAKE) -C lttng
+ endif
+diff --git a/ice/ice_base.c b/ice/ice_base.c
+index e2acab0c0777..25bebea92e6c 100644
+--- a/ice/ice_base.c
++++ b/ice/ice_base.c
+@@ -448,6 +448,10 @@ static int ice_setup_rx_ctx(struct ice_ring *ring)
+ 	/* Rx queue threshold in units of 64 */
+ 	rlan_ctx.lrxqthresh = 1;
+ 
++#ifdef DEV_NETMAP
++	ice_netmap_preconfigure_rx_ring(ring, &rlan_ctx);
++#endif /* DEV_NETMAP */
++
+ 	/* Enable Flexible Descriptors in the queue context which
+ 	 * allows this driver to select a specific receive descriptor format
+ 	 * increasing context priority to pick up profile ID; default is 0x01;
+@@ -599,6 +603,11 @@ int ice_vsi_cfg_rxq(struct ice_ring *ring)
+ 	}
+ #endif /* HAVE_AF_XDP_ZC_SUPPORT */
+ 
++#ifdef DEV_NETMAP
++	if (ice_netmap_configure_rx_ring(ring))
++		return 0;
++#endif /* DEV_NETMAP */
++
+ 	ice_alloc_rx_bufs(ring, num_bufs);
+ 
+ 	return 0;
+@@ -858,6 +867,10 @@ ice_vsi_cfg_txq(struct ice_vsi *vsi, struct ice_ring *ring,
+ 	if (pf_q == le16_to_cpu(txq->txq_id))
+ 		ring->txq_teid = le32_to_cpu(txq->q_teid);
+ 
++#ifdef DEV_NETMAP
++	ice_netmap_configure_tx_ring(ring);
++#endif /* DEV_NETMAP */
++
+ 	return 0;
+ }
+ 
+diff --git a/ice/ice_lib.c b/ice/ice_lib.c
+index 07ce260825c2..aef27b083d84 100644
+--- a/ice/ice_lib.c
++++ b/ice/ice_lib.c
+@@ -2745,6 +2745,11 @@ ice_vsi_setup(struct ice_pf *pf, struct ice_port_info *pi,
+ 	if (!vsi->agg_node)
+ 		ice_set_agg_vsi(vsi);
+ 
++#ifdef DEV_NETMAP
++	if (test_bit(ICE_VSI_NETDEV_REGISTERED, vsi->state))
++		ice_netmap_attach(vsi);
++#endif
++
+ 	return vsi;
+ 
+ unroll_clear_rings:
+@@ -3072,6 +3077,11 @@ int ice_vsi_release(struct ice_vsi *vsi)
+ 		return -ENODEV;
+ 	pf = vsi->back;
+ 
++#ifdef DEV_NETMAP
++	if (test_bit(ICE_VSI_NETDEV_REGISTERED, vsi->state))
++		netmap_detach(vsi->netdev);
++#endif
++
+ 	/* do not unregister while driver is in the reset recovery pending
+ 	 * state. Since reset/rebuild happens through PF service task workqueue,
+ 	 * it's not a good idea to unregister netdev that is associated to the
+diff --git a/ice/ice_main.c b/ice/ice_main.c
+index 9034a27fec4f..2e36789455ab 100644
+--- a/ice/ice_main.c
++++ b/ice/ice_main.c
+@@ -23,6 +23,11 @@
+ #include "ice_tc_lib.h"
+ #include "ice_vsi_vlan_ops.h"
+ #include "ice_fwlog.h"
++#if IS_ENABLED(CONFIG_NETMAP)
++#define NETMAP_ICE_MAIN
++#define DEV_NETMAP
++#include <ice_netmap_linux.h>
++#endif
+ 
+ #define DRV_VERSION_MAJOR 1
+ #define DRV_VERSION_MINOR 6
+diff --git a/ice/ice_txrx.c b/ice/ice_txrx.c
+index c3c2746fe977..34dac5859c57 100644
+--- a/ice/ice_txrx.c
++++ b/ice/ice_txrx.c
+@@ -23,6 +23,11 @@
+ #include "ice_eswitch.h"
+ #include <net/busy_poll.h>
+ 
++#if defined(CONFIG_NETMAP) || defined (CONFIG_NETMAP_MODULE)
++#include <ice_netmap_linux.h>
++#define DEV_NETMAP
++#endif /* DEV_NETMAP */
++
+ #define ICE_RX_HDR_SIZE		256
+ 
+ 
+@@ -234,6 +238,11 @@ static bool ice_clean_tx_irq(struct ice_ring *tx_ring, int napi_budget)
+ 	struct ice_tx_desc *tx_desc;
+ 	struct ice_tx_buf *tx_buf;
+ 
++#ifdef DEV_NETMAP
++	if (tx_ring->netdev && netmap_tx_irq(tx_ring->netdev, tx_ring->q_index) != NM_IRQ_PASS)
++		return true;
++#endif /* DEV_NETMAP */
++
+ 	tx_buf = &tx_ring->tx_buf[i];
+ 	tx_desc = ICE_TX_DESC(tx_ring, i);
+ 	i -= tx_ring->count;
+@@ -1478,6 +1487,16 @@ int ice_clean_rx_irq(struct ice_ring *rx_ring, int budget)
+ 	struct xdp_buff xdp;
+ 	bool failure;
+ 
++#ifdef DEV_NETMAP
++	if (rx_ring->netdev) {
++		int dummy, nm_irq;
++
++		nm_irq = netmap_rx_irq(rx_ring->netdev, rx_ring->q_index, &dummy);
++		if (nm_irq != NM_IRQ_PASS) {
++			return (nm_irq == NM_IRQ_COMPLETED) ? 1 : budget;
++		}
++	}
++#endif /* DEV_NETMAP */
+ #ifdef HAVE_XDP_SUPPORT
+ #ifdef HAVE_XDP_BUFF_RXQ
+ 	xdp.rxq = &rx_ring->xdp_rxq;

--- a/LINUX/ice_netmap_linux.h
+++ b/LINUX/ice_netmap_linux.h
@@ -1,0 +1,588 @@
+/*
+ * Copyright (C) 2021 Intel Corporation. All rights reserved.
+ * Copyright (C) 2015, Luigi Rizzo. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * $FreeBSD$
+ *
+ * netmap support for: ice (LINUX version)
+ *
+ * derived from i40e
+ * netmap support for a network driver.
+ * This file contains code but only static or inline functions used
+ * by a single driver. To avoid replication of code we just #include
+ * it near the beginning of the standard driver.
+ *
+ * This is imported in two places, hence the conditional at the
+ * beginning.
+ */
+
+
+#include <bsd_glue.h>
+#include <net/netmap.h>
+#include <dev/netmap/netmap_kern.h>
+
+int ice_netmap_txsync(struct netmap_kring *kring, int flags);
+int ice_netmap_rxsync(struct netmap_kring *kring, int flags);
+
+#ifdef NETMAP_LINUX_ICE_PTR_ARRAY
+#define NM_ICE_TX_RING(a, r)		((a)->tx_rings[(r)])
+#define NM_ICE_RX_RING(a, r)		((a)->rx_rings[(r)])
+#else
+#define NM_ICE_TX_RING(a, r)		(&(a)->tx_rings[(r)])
+#define NM_ICE_RX_RING(a, r)		(&(a)->rx_rings[(r)])
+#endif
+#ifdef NETMAP_LINUX_ICE_PTR_STATE
+#define NM_ICE_STATE(pf)		(&(pf)->state)
+#else
+#define NM_ICE_STATE(pf)		((pf)->state)
+#endif
+
+#ifdef NETMAP_ICE_MAIN
+
+#define ice_driver_name netmap_ice_driver_name
+char ice_driver_name[] = "ice" NETMAP_LINUX_DRIVER_SUFFIX;
+
+static void
+ice_netmap_configure_tx_ring(struct ice_ring *ring)
+{
+	struct netmap_adapter *na;
+
+	if (!ring->netdev) {
+		// XXX it this possible?
+		return;
+	}
+
+	na = NA(ring->netdev);
+	netmap_reset(na, NR_TX, ring->q_index, 0);
+}
+
+static void
+ice_netmap_preconfigure_rx_ring(struct ice_ring *ring,
+		struct ice_rlan_ctx *rx_ctx)
+{
+	struct netmap_adapter *na;
+	struct netmap_kring *kring;
+
+	if (!ring->netdev) {
+		// XXX it this possible?
+		return;
+	}
+
+	na = NA(ring->netdev);
+
+	if (netmap_reset(na, NR_RX, ring->q_index, 0) == NULL)
+		return;	// not in native netmap mode
+
+	kring = na->rx_rings[ring->q_index];
+	rx_ctx->dbuf = kring->hwbuf_len >> ICE_RLAN_CTX_DBUF_S;
+}
+
+static int
+ice_netmap_configure_rx_ring(struct ice_ring *ring)
+{
+	struct netmap_adapter *na;
+	struct netmap_slot *slot;
+	struct netmap_kring *kring;
+	int lim, i, ring_nr;
+
+	if (!ring->netdev) {
+		// XXX it this possible?
+		return 0;
+	}
+
+	na = NA(ring->netdev);
+	ring_nr = ring->q_index;
+
+	slot = netmap_reset(na, NR_RX, ring_nr, 0);
+	if (!slot)
+		return 0;	// not in native netmap mode
+
+	kring = na->rx_rings[ring_nr];
+	lim = na->num_rx_desc - 1 - nm_kr_rxspace(kring);
+
+	for (i = 0; i < lim; i++) {
+		int si = netmap_idx_n2k(kring, i);
+		uint64_t paddr;
+		union ice_32b_rx_flex_desc *rx = ICE_RX_DESC(ring, i);
+		PNMB_O(kring, slot + si, &paddr);
+
+		rx->read.pkt_addr = htole64(paddr);
+		rx->read.hdr_addr = 0;
+	}
+	ring->next_to_clean = 0;
+	wmb();
+	writel(lim, ring->tail);
+	return 1;
+}
+
+/*
+ * Register/unregister. We are already under netmap lock.
+ * Only called on the first register or the last unregister.
+ */
+static int
+ice_netmap_reg(struct netmap_adapter *na, int onoff)
+{
+	struct ifnet *ifp = na->ifp;
+	struct ice_netdev_priv *np = netdev_priv(ifp);
+	struct ice_vsi  *vsi = np->vsi;
+	struct ice_pf   *pf = (struct ice_pf *)vsi->back;
+	bool was_running;
+
+	while (test_and_set_bit(ICE_CFG_BUSY, NM_ICE_STATE(pf)))
+			usleep_range(1000, 2000);
+
+	if ( (was_running = netif_running(vsi->netdev)) )
+		ice_down(vsi);
+
+	/* enable or disable flags and callbacks in na and ifp */
+	if (onoff) {
+		nm_set_native_flags(na);
+	} else {
+		nm_clear_native_flags(na);
+	}
+	if (was_running) {
+		ice_up(vsi);
+	}
+
+	clear_bit(ICE_CFG_BUSY, NM_ICE_STATE(pf));
+
+	return 0;
+}
+
+static int
+ice_netmap_bufcfg(struct netmap_kring *kring, uint64_t target)
+{
+	uint64_t incr;
+
+	kring->buf_align = 0;
+
+	if (kring->tx == NR_TX) {
+		kring->hwbuf_len = target;
+		return 0;
+	}
+
+	incr = 1UL << ICE_RLAN_CTX_DBUF_S;
+	target &= ~(incr - 1);
+	if (target < 1024UL || target > 16384UL - incr)
+		return EINVAL;
+
+	kring->hwbuf_len = target;
+
+	return 0;
+}
+
+static int
+ice_netmap_config(struct netmap_adapter *na, struct nm_config_info *info)
+{
+	int ret = netmap_rings_config_get(na, info);
+
+	if (ret) {
+		return ret;
+	}
+
+	info->rx_buf_maxsize = NETMAP_BUF_SIZE(na);
+
+	return 0;
+}
+
+/*
+ * The attach routine, called near the end of ice_attach(),
+ * fills the parameters for netmap_attach() and calls it.
+ * It cannot fail, in the worst case (such as no memory)
+ * netmap mode will be disabled and the driver will only
+ * operate in standard mode.
+ */
+static void
+ice_netmap_attach(struct ice_vsi *vsi)
+{
+	struct netmap_adapter na;
+
+	bzero(&na, sizeof(na));
+
+	na.ifp = vsi->netdev;
+	na.pdev = &vsi->back->pdev->dev;
+	na.na_flags = NAF_MOREFRAG | NAF_OFFSETS;
+	na.num_tx_desc = NM_ICE_TX_RING(vsi, 0)->count;
+	na.num_rx_desc = NM_ICE_RX_RING(vsi, 0)->count;
+	na.num_tx_rings = na.num_rx_rings = vsi->num_txq;
+	na.rx_buf_maxsize = vsi->rx_buf_len;
+	na.nm_txsync = ice_netmap_txsync;
+	na.nm_rxsync = ice_netmap_rxsync;
+	na.nm_register = ice_netmap_reg;
+	na.nm_config = ice_netmap_config;
+	na.nm_bufcfg = ice_netmap_bufcfg;
+	netmap_attach(&na);
+}
+
+#else /* NETMAP_ICE_MAIN */
+
+
+/*
+ * Reconcile kernel and user view of the transmit ring.
+ *
+ * All information is in the kring.
+ * Userspace wants to send packets up to the one before kring->rhead,
+ * kernel knows kring->nr_hwcur is the first unsent packet.
+ *
+ * Here we push packets out (as many as possible), and possibly
+ * reclaim buffers from previously completed transmission.
+ *
+ * The caller (netmap) guarantees that there is only one instance
+ * running at any time. Any interference with other driver
+ * methods should be handled by the individual drivers.
+ */
+
+static inline u_int
+ice_netmap_read_hwtail(void *base, int nslots)
+{
+	struct ice_tx_desc *desc = base;
+	return le32toh(*(volatile __le32 *)&desc[nslots]);
+}
+
+int
+ice_netmap_txsync(struct netmap_kring *kring, int flags)
+{
+	struct netmap_adapter *na = kring->na;
+	struct ifnet *ifp = na->ifp;
+	struct netmap_ring *ring = kring->ring;
+	u_int nm_i;	/* index into the netmap ring */
+	u_int nic_i;	/* index into the NIC ring */
+	u_int n;
+	u_int const lim = kring->nkr_num_slots - 1;
+	u_int const head = kring->rhead;
+	/*
+	 * interrupts on every tx packet are expensive so request
+	 * them every half ring, or where NS_REPORT is set
+	 */
+	u_int report_frequency = kring->nkr_num_slots >> 1;
+
+	/* device-specific */
+	struct ice_netdev_priv *np = netdev_priv(ifp);
+	struct ice_vsi *vsi = np->vsi;
+	struct ice_ring *txr;
+
+	if (!netif_carrier_ok(ifp))
+		return 0;
+
+	txr = NM_ICE_TX_RING(vsi, kring->ring_id);
+	if (unlikely(!txr || !txr->desc)) {
+		nm_prlim(1, "ring %s is missing (txr=%p)", kring->name, txr);
+		return ENXIO;
+	}
+
+	/*
+	 * First part: process new packets to send.
+	 * nm_i is the current index in the netmap ring,
+	 * nic_i is the corresponding index in the NIC ring.
+	 * The two numbers differ because upon a *_init() we reset
+	 * the NIC ring but leave the netmap ring unchanged.
+	 * For the transmit ring, we have
+	 *
+	 *		nm_i = kring->nr_hwcur
+	 *		nic_i = IXGBE_TDT (not tracked in the driver)
+	 * and
+	 * 		nm_i == (nic_i + kring->nkr_hwofs) % ring_size
+	 *
+	 * In this driver kring->nkr_hwofs >= 0, but for other
+	 * drivers it might be negative as well.
+	 */
+
+	/*
+	 * If we have packets to send (kring->nr_hwcur != kring->rhead)
+	 * iterate over the netmap ring, fetch length and update
+	 * the corresponding slot in the NIC ring. Some drivers also
+	 * need to update the buffer's physical address in the NIC slot
+	 * even NS_BUF_CHANGED is not set (PNMB computes the addresses).
+	 *
+	 * The netmap_reload_map() calls is especially expensive,
+	 * even when (as in this case) the tag is 0, so do only
+	 * when the buffer has actually changed.
+	 *
+	 * If possible do not set the report/intr bit on all slots,
+	 * but only a few times per ring or when NS_REPORT is set.
+	 *
+	 * Finally, on 10G and faster drivers, it might be useful
+	 * to prefetch the next slot and txr entry.
+	 */
+
+	nm_i = kring->nr_hwcur;
+	if (nm_i != head) {	/* we have new packets to send */
+		nic_i = netmap_idx_k2n(kring, nm_i);
+
+		__builtin_prefetch(&ring->slot[nm_i]);
+		__builtin_prefetch(ICE_TX_DESC(txr, nic_i));
+
+		for (n = 0; nm_i != head; n++) {
+			struct netmap_slot *slot = &ring->slot[nm_i];
+			u_int len = slot->len;
+			uint64_t paddr;
+			uint64_t offset = nm_get_offset(kring, slot);
+
+			/* device-specific */
+			struct ice_tx_desc *curr = ICE_TX_DESC(txr, nic_i);
+			u64 hw_flags = 0;
+
+			/* prefetch for next round */
+			__builtin_prefetch(&ring->slot[nm_i + 1]);
+			__builtin_prefetch(ICE_TX_DESC(txr, nic_i));
+
+			PNMB(na, slot, &paddr);
+			NM_CHECK_ADDR_LEN_OFF(na, len, offset);
+
+			if (!(slot->flags & NS_MOREFRAG)) {
+				hw_flags |= ((u64)(ICE_TX_DESC_CMD_EOP) <<
+						ICE_TXD_QW1_CMD_S);
+				if (slot->flags & NS_REPORT || nic_i == 0 ||
+						nic_i == report_frequency) {
+					hw_flags |= ((u64)ICE_TX_DESC_CMD_RS <<
+							ICE_TXD_QW1_CMD_S);
+				}
+			}
+			if (slot->flags & NS_BUF_CHANGED) {
+				/* buffer has changed, reload map */
+				//netmap_reload_map(na, txr->dma.tag, txbuf->map, addr);
+			}
+			slot->flags &= ~(NS_REPORT | NS_BUF_CHANGED | NS_MOREFRAG);
+
+			netmap_sync_map_dev(na, (bus_dma_tag_t) na->pdev,
+					&paddr, len, NR_TX);
+			/* Fill the slot in the NIC ring.
+			 * (we should investigate if using legacy descriptors
+			 * is faster). */
+			curr->buf_addr = htole64(paddr + offset);
+			curr->cmd_type_offset_bsz = htole64(
+			    ((u64)len << ICE_TXD_QW1_TX_BUF_SZ_S) |
+			    hw_flags
+			  ); /* more flags may be needed */
+
+			nm_i = nm_next(nm_i, lim);
+			nic_i = nm_next(nic_i, lim);
+		}
+		kring->nr_hwcur = head;
+
+		/* synchronize the NIC ring */
+		//bus_dmamap_sync(txr->dma.tag, txr->dma.map,
+		//	BUS_DMASYNC_PREREAD | BUS_DMASYNC_PREWRITE);
+
+		/* (re)start the tx unit up to slot nic_i (excluded) */
+		wmb();
+		writel(nic_i, txr->tail);
+	}
+
+	/*
+	 * Second part: reclaim buffers for completed transmissions.
+	 */
+	nic_i = ice_netmap_read_hwtail(txr->desc, kring->nkr_num_slots);
+	if (nic_i != txr->next_to_clean) {
+		u_int tosync;
+		nm_i = netmap_idx_n2k(kring, nic_i);
+
+		/* some tx completed, increment avail */
+		txr->next_to_clean = nic_i;
+		tosync = nm_next(kring->nr_hwtail, lim);
+		/* sync all buffers that we are returning to userspace */
+		for ( ; tosync != nm_i; tosync = nm_next(tosync, lim)) {
+			struct netmap_slot *slot = &ring->slot[tosync];
+			uint64_t paddr;
+			(void)PNMB_O(kring, slot, &paddr);
+
+			netmap_sync_map_cpu(na, (bus_dma_tag_t) na->pdev,
+					&paddr, slot->len, NR_TX);
+		}
+		kring->nr_hwtail = nm_prev(nm_i, lim);
+	}
+
+	return 0;
+}
+
+
+/*
+ * Reconcile kernel and user view of the receive ring.
+ * Same as for the txsync, this routine must be efficient.
+ * The caller guarantees a single invocations, but races against
+ * the rest of the driver should be handled here.
+ *
+ * On call, kring->rhead is the first packet that userspace wants
+ * to keep, and kring->rcur is the wakeup point.
+ * The kernel has previously reported packets up to kring->rtail.
+ *
+ * If (flags & NAF_FORCE_READ) also check for incoming packets irrespective
+ * of whether or not we received an interrupt.
+ */
+int
+ice_netmap_rxsync(struct netmap_kring *kring, int flags)
+{
+	struct netmap_adapter *na = kring->na;
+	struct ifnet *ifp = na->ifp;
+	struct netmap_ring *ring = kring->ring;
+	u_int nm_i;	/* index into the netmap ring */
+	u_int nic_i;	/* index into the NIC ring */
+	u_int ntail;	/* new tail for the user */
+	u_int n;
+	u_int const lim = kring->nkr_num_slots - 1;
+	u_int const head = kring->rhead;
+	int force_update = (flags & NAF_FORCE_READ) || kring->nr_kflags & NKR_PENDINTR;
+
+	/* device-specific */
+	struct ice_netdev_priv *np = netdev_priv(ifp);
+	struct ice_vsi *vsi = np->vsi;
+	struct ice_ring *rxr;
+
+	if (!netif_running(ifp))
+		return 0;
+
+	rxr = NM_ICE_RX_RING(vsi, kring->ring_id);
+	if (unlikely(!rxr || !rxr->desc)) {
+		nm_prlim(1, "ring %s is missing (rxr=%p)", kring->name, rxr);
+		return ENXIO;
+	}
+
+	if (head > lim)
+		return netmap_ring_reinit(kring);
+
+	/* XXX check sync modes */
+	//bus_dmamap_sync(rxr->dma.tag, rxr->dma.map,
+	//		BUS_DMASYNC_POSTREAD | BUS_DMASYNC_POSTWRITE);
+
+	/*
+	 * First part: import newly received packets.
+	 *
+	 * nm_i is the index of the next free slot in the netmap ring,
+	 * nic_i is the index of the next received packet in the NIC ring,
+	 * and they may differ in case if_init() has been called while
+	 * in netmap mode. For the receive ring we have
+	 *
+	 *	nic_i = rxr->next_check;
+	 *	nm_i = kring->nr_hwtail (previous)
+	 * and
+	 *	nm_i == (nic_i + kring->nkr_hwofs) % ring_size
+	 *
+	 * rxr->next_check is set to 0 on a ring reinit
+	 */
+	if (netmap_no_pendintr || force_update) {
+		int complete;
+
+		nic_i = rxr->next_to_clean; // or also k2n(kring->nr_hwtail)
+		nm_i = netmap_idx_n2k(kring, nic_i);
+		/* we advance tail only when we see a complete packet */
+		ntail = lim + 1;
+		complete = 0;
+
+		for (n = 0; ; n++) {
+			union ice_32b_rx_flex_desc *curr = ICE_RX_DESC(rxr, nic_i);
+			uint16_t staterr = le16toh(curr->wb.status_error0);
+		        uint16_t slot_flags = 0;
+			struct netmap_slot *slot;
+			uint64_t paddr;
+
+			if (likely(complete)) {
+				ntail = nm_i;
+				complete = 0;
+			}
+
+			if ((staterr & (1<<ICE_RX_FLEX_DESC_STATUS0_DD_S)) == 0) {
+				break;
+			}
+			slot = ring->slot + nm_i;
+			slot->len = le16toh(curr->wb.pkt_len);
+
+			if (unlikely((staterr & (1<<ICE_RX_FLEX_DESC_STATUS0_EOF_S)) == 0 )) {
+				slot_flags = NS_MOREFRAG;
+			} else {
+				complete = 1;
+			}
+			slot->flags = slot_flags;
+			PNMB_O(kring, slot, &paddr);
+			netmap_sync_map_cpu(na, (bus_dma_tag_t) na->pdev,
+					&paddr, slot->len, NR_RX);
+
+			nm_i = nm_next(nm_i, lim);
+			nic_i = nm_next(nic_i, lim);
+		}
+		if (n) { /* update the state variables */
+			rxr->next_to_clean = nic_i;
+			if (likely(ntail <= lim)) {
+				kring->nr_hwtail = ntail;
+				nm_prdis("%s: nic_i %u nm_i %u ntail %u n %u", ifp->if_xname, nic_i, nm_i, ntail, n);
+			}
+		}
+		kring->nr_kflags &= ~NKR_PENDINTR;
+	}
+
+	/*
+	 * Second part: skip past packets that userspace has released.
+	 * (kring->nr_hwcur to kring->rhead excluded),
+	 * and make the buffers available for reception.
+	 * As usual nm_i is the index in the netmap ring,
+	 * nic_i is the index in the NIC ring, and
+	 * nm_i == (nic_i + kring->nkr_hwofs) % ring_size
+	 */
+	nm_i = kring->nr_hwcur;
+	if (nm_i != head) {
+		nic_i = netmap_idx_k2n(kring, nm_i);
+		for (n = 0; nm_i != head; n++) {
+			struct netmap_slot *slot = &ring->slot[nm_i];
+			uint64_t paddr;
+			void *addr = PNMB(na, slot, &paddr);
+			uint64_t offset = nm_get_offset(kring, slot);
+
+			union ice_32b_rx_flex_desc *curr = ICE_RX_DESC(rxr, nic_i);
+
+			if (addr == NETMAP_BUF_BASE(na)) /* bad buf */
+				goto ring_reset;
+
+			if (slot->flags & NS_BUF_CHANGED) {
+				/* buffer has changed, reload map */
+				//netmap_reload_map(na, rxr->ptag, rxbuf->pmap, addr);
+				slot->flags &= ~NS_BUF_CHANGED;
+			}
+			curr->read.pkt_addr = htole64(paddr + offset);
+			curr->wb.status_error0 = 0;
+			netmap_sync_map_dev(na, (bus_dma_tag_t) na->pdev,
+					&paddr, NETMAP_BUF_SIZE(na), NR_RX);
+			nm_i = nm_next(nm_i, lim);
+			nic_i = nm_next(nic_i, lim);
+		}
+		kring->nr_hwcur = head;
+
+		/*
+		 * IMPORTANT: we must leave one free slot in the ring,
+		 * so move nic_i back by one unit
+		 */
+		nic_i = nm_prev(nic_i, lim);
+		wmb();
+		writel(nic_i, rxr->tail);
+	}
+
+	return 0;
+
+ring_reset:
+	return netmap_ring_reinit(kring);
+}
+
+#endif /* NETMAP_ICE_MAIN */
+
+/* end of file */

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ some netmap-enabled device drivers.
 Please look [here](LINUX/README.md) for more instructions.
 
 Make sure you have kernel headers matching your installed kernel.
-The sources for e1000e, igb, ixgbe and i40e will be downloaded
+The sources for e1000e, igb, ixgbe, ice and i40e will be downloaded
 from the Intel e1000 project on sourceforce.
 If you need the netmap enabled drivers for e1000, veth, forcedeth,
 virtio-net or r8169 you will also need the full kernel sources.

--- a/ci/build-linux
+++ b/ci/build-linux
@@ -93,7 +93,7 @@ make -j $PROC_COUNT
 # Then build external intel drivers
 make distclean
 echo "Building external intel drivers (and virtio_net.c)"
-EXTDRIVERS="e1000e,igb,ixgbe,i40e"
+EXTDRIVERS="e1000e,igb,ixgbe,i40e,ice"
 # For kernels >= 3.13 we support virtio_net.c as an external driver
 cmp=$(kverless $KERNEL_VERSION 3.10)
 if [ "$cmp" == "1" ]; then
@@ -105,5 +105,5 @@ make -j $PROC_COUNT
 # Then build vanilla intel drivers
 make distclean
 echo "Building vanilla intel drivers"
-./configure --no-ext-drivers --kernel-dir=$PWD/linux-${KERNEL_VERSION} --driver-suffix=_netmap --drivers=e1000e,igb,ixgbe,i40e
+./configure --no-ext-drivers --kernel-dir=$PWD/linux-${KERNEL_VERSION} --driver-suffix=_netmap --drivers=e1000e,igb,ixgbe,i40e,ice
 make -j $PROC_COUNT

--- a/pre-commit
+++ b/pre-commit
@@ -39,7 +39,7 @@ EOF
 fi
 
 ########### netmap specific checks ############
-files="sys/dev/netmap/netmap_vale.c sys/dev/netmap/netmap_monitor.c sys/dev/netmap/netmap_pipe.c sys/dev/netmap/netmap.c sys/dev/netmap/netmap_generic.c sys/dev/netmap/netmap_freebsd.c sys/dev/netmap/netmap_legacy.c LINUX/netmap_linux.c LINUX/bsd_glue.h LINUX/i40e_netmap_linux.h LINUX/if_e1000_netmap.h LINUX/if_e1000e_netmap.h LINUX/if_igb_netmap.h LINUX/if_re_netmap_linux.h LINUX/ixgbe_netmap_linux.h LINUX/veth_netmap.h LINUX/virtio_netmap.h LINUX/netmap_ptnet.c LINUX/forcedeth_netmap.h apps/bridge/bridge.c apps/lb/lb.c apps/vale-ctl/vale-ctl.c apps/dedup/dedup.c apps/include/ctrs.h"
+files="sys/dev/netmap/netmap_vale.c sys/dev/netmap/netmap_monitor.c sys/dev/netmap/netmap_pipe.c sys/dev/netmap/netmap.c sys/dev/netmap/netmap_generic.c sys/dev/netmap/netmap_freebsd.c sys/dev/netmap/netmap_legacy.c LINUX/netmap_linux.c LINUX/bsd_glue.h LINUX/i40e_netmap_linux.h LINUX/ice_netmap_linux.h LINUX/if_e1000_netmap.h LINUX/if_e1000e_netmap.h LINUX/if_igb_netmap.h LINUX/if_re_netmap_linux.h LINUX/ixgbe_netmap_linux.h LINUX/veth_netmap.h LINUX/virtio_netmap.h LINUX/netmap_ptnet.c LINUX/forcedeth_netmap.h apps/bridge/bridge.c apps/lb/lb.c apps/vale-ctl/vale-ctl.c apps/dedup/dedup.c apps/include/ctrs.h"
 
 for f in $files; do
 	ERR=$(git grep --line-number "^\(     \)\+" $f | head -n1)

--- a/share/man/man4/netmap.4
+++ b/share/man/man4/netmap.4
@@ -834,7 +834,7 @@ On
 .Xr re 4 ,
 .Xr vtnet 4 .
 .Pp
-On Linux e1000, e1000e, i40e, igb, ixgbe, ixgbevf, r8169, virtio_net, vmxnet3.
+On Linux e1000, e1000e, i40e, ice, igb, ixgbe, ixgbevf, r8169, virtio_net, vmxnet3.
 .Pp
 NICs without native support can still be used in
 .Nm

--- a/sys/net/netmap.h
+++ b/sys/net/netmap.h
@@ -214,7 +214,7 @@ struct netmap_slot {
 #define	NS_MOREFRAG	0x0020	/* packet has more fragments */
  	/*
 	 * (VALE ports, ptnetmap ports and some NIC ports, e.g.
-         * ixgbe and i40e on Linux)
+         * ixgbe, ice, and i40e on Linux)
 	 * Set on all but the last slot of a multi-segment packet.
 	 * The 'len' field refers to the individual fragment.
 	 */


### PR DESCRIPTION
Add the ice driver to the build system to fetch the drivers-ext from
sourceforge and build it as part of netmap.

Signed-off-by: Jesse Brandeburg <jesse.brandeburg@intel.com>